### PR TITLE
Finish SIL listings beginning in a-; make a few changes to the scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ In some cases, phonemes may be too underspecified or under-described to be easil
 
 - The source must be a phoneme listed in `phonemes`.
 - The realization must be a phoneme.
-- The environment may be free-form text.
+- The environment is optional, and may be free-form text.
 
 In cases where an entire cluster or sequence has a specific realization, such as English /nð/ > [n̪ː], join the source phonemes in the sequence with a plus sign: `n+ð > n̪ː`. If this rule has no conditioning factor outside the cluster itself, the `/ environment` component may be omitted.
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ For cases of free variation, such as Nuosu `m+ɨ >~ m̩`, use the digraph `>~`. 
 
 For fricated or 'super-close' vowels such as the 'apical vowel' of Mandarin, use the Sinological characters: `ɿ` instead of `i̝` or `z̩`, `ʮ` instead of `y̝` or `ʑ̩ʷ`, and so on. For the fricated back rounded vowel, use `ꭒ` instead of `v̩`.
 
+The IPA palatal series is here interpreted as velar palatals; coronal palatals are represented by the Sinological `ȶ` series.
+
 # Example
 
 An example file, `roto1249-1.ini`, is given below.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Entry files have five headers: `core`, `source`, (optionally) `notes`, `phonemes
 - `name`: the name of the doculect as given in the source
 - `glottocode`: the Glottocode of the language
 
-And two optional attributes:
-- `notes`: Any notes relevant to the entry.
+And three optional attributes:
+- `notes`: any notes relevant to the entry
 - `dialect`: the Glottocode of the specific dialect, if one is defined
+- `dialect_name`: the name of the specific dialect as given in the source, if a specific dialect is referenced
 
 ### `source`
 

--- a/commit.py
+++ b/commit.py
@@ -43,6 +43,9 @@ def no(section, prop):
 		return True
 	return False
 
+def get_canonical(phoneme):
+	return re.sub(r'[\(\)\{\}]', '', phoneme.split('|')[0])
+
 # -- Tests -- 
 def validate(doculect):
 	if set(doculect.sections()) != set(['core', 'source', 'notes', 'phonemes', 'allophonic_rules']):
@@ -81,7 +84,7 @@ def validate(doculect):
 	if 'y' in phonemes:
 		print('Warning: /y/ listed in phonemes - make sure you don\'t mean /j/!')
 
-	canonical_phonemes = [phoneme.split('|')[0] for phoneme in phonemes]
+	canonical_phonemes = [get_canonical(phoneme) for phoneme in phonemes]
 
 	# -- Allophonic rules tests --
 	for rule_raw in doculect['allophonic_rules']:

--- a/commit.py
+++ b/commit.py
@@ -75,7 +75,7 @@ def validate(doculect):
 	if set(phonemes) != set(doculect['phonemes']):
 		raise InvalidPropertyError('Duplicate phoneme')
 
-	if phonemes[0] == 'REQUIRED':
+	if len(phonemes) == 0 or phonemes[0] == 'required':
 		raise MissingPropertyError('No phonemes given')
 
 	if 'y' in phonemes:

--- a/commit.py
+++ b/commit.py
@@ -65,6 +65,9 @@ def validate(doculect):
 	if phonemes[0] == 'REQUIRED':
 		raise Exception('No phonemes given')
 
+	if 'y' in phonemes:
+		print('Warning: /y/ listed in phonemes - make sure you don\'t mean /j/!')
+
 	canonical_phonemes = [phoneme.split('|')[0] for phoneme in phonemes]
 
 	# -- Allophonic rules tests --

--- a/commit.py
+++ b/commit.py
@@ -5,11 +5,14 @@ import configparser
 
 def parse_allophonic_rule(line):
 	if not re.fullmatch('[^>]+>[^\/]+\/[^>\/\n]+', line):
-		raise Exception('Invalid allophonic rule: {}'.format(line))
+		environment = None
+		if not re.fullmatch('[^>]+>[^\/]+', line):
+			raise Exception('Invalid allophonic rule: {}'.format(line))
+	else:
+		environment = re.search('/(.+)', line).group(1).strip()
 
 	phonemes = re.match('[^>]+', line).group(0).strip().split('+')
 	allophone = re.search('>([^/]+)', line).group(1).strip()
-	environment = re.search('/(.+)', line).group(1).strip()
 	rule_type = 'strict'
 
 	if allophone[0] == '~':

--- a/doculects/alam1246-1.ini
+++ b/doculects/alam1246-1.ini
@@ -1,0 +1,81 @@
+[core]
+name = Alamblak
+glottocode = alam1246
+
+[source]
+glottolog = 310156
+url = http://sealang.net/archives/pl/pdf/PL-C81.pdf
+author = Bruce, Les
+title = The Alamblak language of Papua New Guinea (East Sepik)
+year = 1984
+
+[notes]
+	/s ʃ tʃ/ are in free variation in certain words, but not others: [na{s ʃ tʃ}uŋˈgwaɾɨm] 'guardian spirits', but [suit] 'skirt'. In some words, only /s ʃ/ are in free variation: [ˈsuɣ] ~ [ˈʃuɣ] 'fall'.
+
+	ɨ harmony may apply to allophones aside from ʊ ŏ; the text is unclear.
+
+[phonemes]
+p
+t
+k
+b
+d
+g
+m
+n
+ɸ
+s
+x
+w
+j
+ɾ
+(tʃ)
+(dʒ)
+(ɲ)
+(ʃ)
+a
+e
+ə
+o
+i
+ɨ
+u
+
+[allophonic_rules]
+ɸ > β / [+voice -nasal]_[+voice]
+x > ɣ / [+voice -nasal]_[+voice]
+ɸ > b / _[+voice labial]
+x > g / _[+voice velar]
+ɾ > ɾ̥ / _# or _[-voice]
+w > o̯ / V[-high]_C[-coronal]
+t > tʃ / C[+palatal]_
+d > dʒ / C[+palatal]_
+n > ɲ / C[+palatal]_
+s > ʃ / C[+palatal]_
+j+t > tʃ / _
+j+d > dʒ / _
+j+n > ɲ / _
+j+s > ʃ / _ 
+
+i > ɪ / _ɾ
+i > ɪ / C[palatoalveolar]_
+i > ɪ~i / j_
+
+e > ɛ / unstressed
+e > ɛ / _C[labial] or _C# when stressed (?)
+e > i / _e (including [e] from /aj/) - but this rule only exists to explain forms of /najaj/ 'come'?
+
+o > ŏ / C[velar]_C[alveolar]
+
+a > ə / _($<ɨ>)+a (that is, "preceding a syllable containing an [a] with or without one or more intervening syllables which contain a high central vocoid")
+
+ə > ɔ / [+labial]_# 
+ə >~ ɨ / pretonic
+ə > o / Cw_"{[+periph] [+medial -nasal]}" (what? TODO)
+ə > o / C[+labial]_w(C)
+
+ɨ > ʊ / w_
+ɨ > ŏ / [+labial]_x
+
+ɨ > ʊ / ʊ$_
+ɨ > ŏ / ŏ$_

--- a/doculects/alaw1244-1.ini
+++ b/doculects/alaw1244-1.ini
@@ -1,0 +1,72 @@
+[core]
+name = Alawa
+glottocode = alaw1244
+
+[source]
+glottolog = 57806
+url = https://archive.org/details/alawaphonologygr0000shar/
+author = Cunningham, Margaret
+title = Alawa Phonology and Grammar
+year = 1969
+
+[notes]
+The alveolopalatal series is given as alveolopalatal, but described as primarily 'alveodental' - these are given here as allophones, and marked as laminal alveolar.
+
+[phonemes]
+ⁿb
+p
+m
+w
+ⁿg
+k
+ŋ
+ⁿȡ
+ȶ
+ȵ
+ȴ
+j
+ⁿɖ
+ʈ
+ɳ
+ɭ
+ⁿd
+t|t̠
+n|n̠
+l|l̠
+ɾ|r
+ɹ
+
+a
+e
+i
+u
+
+[allophonic_rules]
+p >~ b / most word-medial positions and most word-initial occurrences
+k >~ g / most word-medial positions and most word-initial occurrences
+ȶ >~ ȡ / most word-medial positions and most word-initial occurrences
+ʈ >~ ɖ / most word-medial positions and most word-initial occurrences
+t >~ d / most word-medial positions and most word-initial occurrences
+
+p >~ pʰ / word-finally in a stressed word
+k >~ kʰ / word-finally in a stressed word
+ȶ >~ ȶʰ / word-finally in a stressed word
+ʈ >~ ʈʰ / word-finally in a stressed word
+t >~ tʰ / word-finally in a stressed word
+
+ɾ > ɾ̝ / _i or i_
+ɾ >~ ɹ̝
+ɾ > r̥ / _#
+ɾ >~ r / _C
+
+n > ɾ̃ / _$ ("may have flap onset syllable finally")
+l > ɺ / _$ ("may have flap onset syllable finally")
+
+ȶ > t̻ / "Alveolopalatals, not including the semivowel, have alveolopalatal articulation when contiguous to alveolar or retroflexed alveolar consonants within a word, and alveodental articulation elsewhere."
+ⁿȡ > d̻ / "Alveolopalatals, not including the semivowel, have alveolopalatal articulation when contiguous to alveolar or retroflexed alveolar consonants within a word, and alveodental articulation elsewhere."
+ȵ > n̻ / "Alveolopalatals, not including the semivowel, have alveolopalatal articulation when contiguous to alveolar or retroflexed alveolar consonants within a word, and alveodental articulation elsewhere."
+
+
+k > c / i_ e_ or contiguous to alveopalatal consonants
+ⁿg > ɟ / i_ e_ or contiguous to alveopalatal consonants
+ŋ > ɲ / i_ e_ or contiguous to alveopalatal consonants

--- a/doculects/alek1238-1.ini
+++ b/doculects/alek1238-1.ini
@@ -1,0 +1,48 @@
+[core]
+name = Alekano
+glottocode = alek1238
+
+[source]
+url = https://www.silpacific.org/resources/archives/42307
+author = Deibler, Ellis W.
+title = Alekano Organised Phonology Data
+publisher = SIL
+year = 1992
+pages = 4
+
+[notes]
+/w/ is found only in the village name Wanima and its derivations, and in "Pidgin loanwords".
+
+Rather than listing the glottal stop as a consonant, Deibler lists a complete series of "vowels with glottal closure" and notes that this glottal vowel closure was previously described as a consonant. These are notated here as glottalized vowels. (TODO: maybe we should have a different notation for these?)
+
+[phonemes]
+p
+t
+k
+m
+n
+β
+s
+z
+ɣ
+h
+l
+{(w)}
+
+a|ɑ
+e
+ɤ
+i
+ɯ
+
+aˀ|ɑˀ
+eˀ
+ɤˀ
+iˀ
+uˀ
+
+˥
+˩
+
+[allophonic_rules]
+l > ɽ / word-medially

--- a/doculects/alek1238-2.ini
+++ b/doculects/alek1238-2.ini
@@ -1,0 +1,44 @@
+[core]
+name = Gahuku
+glottocode = alek1238
+
+[source]
+glottolog = 72887
+url = https://archive.org/details/rosettaproject_kbq_phon-1
+author = Young, Rosemary
+title = The phonemes of Kanite, Kamano, Benabena, and Gahuku
+year = 1962
+
+[notes]
+High tone is stated to contrast with either low tone or tonelessness; the latter interpretation is taken here.
+
+It's unclear whether /b/ is a stop or a fricative. (TODO: compare with other sources?)
+
+A page may be missing from the archive.org copy of the source.
+
+[phonemes]
+p
+t
+k
+ʔ
+b
+z
+ɣ
+w
+s
+h
+ɽ|ɭ̆
+m
+n
+
+a
+e
+o
+i
+u
+
+˥
+
+[allophonic_rules]
+z >~ dz / "with a few speakers"
+e > ɛ / _ʔ

--- a/doculects/amai1246-1.ini
+++ b/doculects/amai1246-1.ini
@@ -1,0 +1,44 @@
+[core]
+name = Amaimon
+glottocode = amai1246
+
+[source]
+url = https://www.silpacific.org/resources/archives/42379
+author = Lillie, Patricia
+title = Amaimon Organised Phonology Data
+publisher = SIL
+year = 2001
+
+[notes]
+
+[phonemes]
+p
+b
+t
+d
+k
+g
+m
+n
+ɲ
+ɾ
+s
+z
+w
+l
+
+j
+dz
+kʷ
+
+a|ɑ
+e
+i
+o
+u
+
+ai
+au
+oi
+
+[allophonic_rules]

--- a/doculects/aman1265-1.ini
+++ b/doculects/aman1265-1.ini
@@ -1,0 +1,52 @@
+[core]
+name = Amanab
+glottocode = aman1265
+
+[source]
+url = https://www.silpacific.org/resources/archives/42411
+author = Unknown
+title = Amanab Organised Phonology Data
+publisher = SIL
+year = 1998
+
+[notes]
+
+
+[phonemes]
+p
+t
+k
+m
+n
+ɾ|l
+ɸ
+s
+ɣ
+h
+j
+w
+ⁿb
+(ⁿd)
+ⁿg
+
+a|ɑ
+e|ɛ
+i
+o|ɔ
+u
+
+ai|ɑi
+au|ɑu
+oi|ɔi
+ou|ɔu
+ei|ɛi
+ii
+
+[allophonic_rules]
+ⁿg > g / #_
+k > kʟ̥ / _#
+ɸ >~ β / word-medially
+ɸ > pɸ / _#
+h >~ x / _#
+e > æ / word-medially, especially in stressed open syllables
+a > ɐ / in unstressed syllables

--- a/doculects/amap1240-1.ini
+++ b/doculects/amap1240-1.ini
@@ -1,0 +1,55 @@
+[core]
+name = Ama
+glottocode = amap1240
+
+[source]
+url = https://www.silpacific.org/resources/archives/42374
+author = Årsjö, Britten; Årsjö, Sören
+title = Ama Organised Phonology Data
+publisher = SIL
+year = 1994
+
+[notes]
+A phonemic nasal vowel appears in one word, /ã/ "tree".
+
+[phonemes]
+p
+t
+k
+m
+n
+ɸ
+s
+h
+j
+ɭ
+w
+kʷ
+
+a
+ɒ|ə|ʌ
+(ɔ)
+(e)
+(o)
+i
+u
+(ã)
+
+ai
+au
+ʌi
+ʌu
+
+˩˥
+˩˥˩
+
+[allophonic_rules]
+ɸ > ʍ / _u
+s > s̠
+ɭ > r / V_ (? - unclear)
+
+ʌi >~ ɛɪ
+
+ɒ > ə̆ / {p f m t k}_ɭ {f m k}_n
+ɒ > ə / pre-stress non-initial CV syllables, unless the onset is a semivowel
+ɒ > ʌ / post-stress non-final syllables, or non-final unstressed syllables with semivowel onset

--- a/doculects/ambu1247-1.ini
+++ b/doculects/ambu1247-1.ini
@@ -1,0 +1,65 @@
+[core]
+name = Abulas
+glottocode = ambu1247
+
+[source]
+glottolog = 37054
+url = https://www.silpacific.org/resources/archives/31151
+author = Wearne, Helen; Wilson, Patricia R.
+title = Abulas phonemes
+year = 1970
+
+[notes]
+/w/ is weak and unwritten between bilabials and front vowels.
+
+[phonemes]
+p
+t
+s|s̪|ɕ|ts|ts̪|tɕ
+k
+ⁿb
+ⁿd
+ⁿdʑ
+ⁿg
+m
+n
+ȵ
+ŋ
+β
+l
+ɾ
+w
+j
+
+i
+ɨ
+u
+e
+ə
+o
+a
+
+[allophonic_rules]
+p > pʰ / $_
+p >~ pⁿ / _# "only occasionally with older speakers"
+
+t > tʰ / $_
+t >~ tⁿ / _# "only occasionally with older speakers"
+
+s > z̪ / V_V
+s >~ t* / _ⁿdʑ (unclear what this is supposed to represent or what diacritic is given)
+
+k > kʰ / $_
+k >~ kⁿ / _# "only occasionally with older speakers"
+
+l > l̪ / adjacent to front vowels
+ɾ > r / #_
+
+i > ɪ / closed syllables
+e > ɛ / closed syllables
+ɨ > ᵻ / closed syllables
+ə > ʌ / closed syllables and word-finally
+a > ɐ / closed syllables
+u >~ ʊ / _ 
+o >~ ɔ / open syllables
+o > ɒ / closed syllables ("low close back rounded")

--- a/doculects/ambu1247-2.ini
+++ b/doculects/ambu1247-2.ini
@@ -1,0 +1,47 @@
+[core]
+name = Ambulas
+glottocode = ambu1247
+
+[source]
+url = https://www.silpacific.org/resources/archives/42228
+author = Wilson, Patricia R.
+title = Ambulas Organised Phonology Data
+publisher = SIL
+year = 1996
+
+[notes]
+
+[phonemes]
+p
+t
+k
+m
+n
+ȵ
+ŋ
+r
+β
+s|ts
+j
+l
+ⁿb
+ⁿbʷ
+ⁿd
+ⁿg
+ⁿgʷ
+ⁿdʑ
+kʷ
+mʷ
+ŋʷ
+pʷ
+
+a|ɑ
+ɐ
+e
+o
+i
+ɨ
+u
+
+[allophonic_rules]
+s > z / V_V

--- a/doculects/amel1241-1.ini
+++ b/doculects/amel1241-1.ini
@@ -1,0 +1,75 @@
+[core]
+name = Amele
+glottocode = amel1241
+
+[source]
+glottolog = 551784
+url = https://www.silpacific.org/resources/archives/68531
+author = Roberts, John R.
+title = Amele RRG Grammatical Sketch
+publisher = SIL
+year = 2016
+
+[notes]
+/k/ only contrasts with /g/ word-initially. 
+
+/p/ isn't listed as a phoneme, but is listed in some words, including [sæˈpɔl] ~ [sæˈfɔl] "axe (Russian loan word)". 
+
+Marginal phonemes that are listed here but aren't given as phonemes in the source: /ʒ/, /ɪ/, /ɔ/. 
+
+[phonemes]
+b
+gb
+d
+t
+g
+(k)
+ʔ
+f
+s
+h
+m
+n
+l
+w
+j
+(p|f)
+
+a
+e|ɛ
+o
+i
+u
+
+(ʒ)
+(ɪ)
+(ɔ)
+
+
+[allophonic_rules]
+b > p / _# in polysyllabic words
+gb > p / _#
+g > k / _#
+
+w > ʋ / #_{i e} i_# V_{i e}
+j > ʒ / #_, i_#, V_i, optionally adjacent to [æ]; but also in reduplication and arbitrarily in some verb stems
+
+i > ɪ / _{l m n} except in [bæ.ˈhim] "platform"
+i >~ ɪ
+
+e+e > ɛː
+e+u > ɛʊ
+e > ɛ / everywhere except word-finally and before /i/
+
+a > æ / most environments
+a > æː / in monosyllables when preceding a voiced stop
+a+i > aɪ
+a+u > ɑʊ
+a > ə / _# when unstressed in polysyllables
+
+o > ɔ / everywhere but word-finally
+o+o > ɔɔ
+o+o > oʊ
+
+u > ʊ / in closed syllables preceding /m/
+u >~ ʊ

--- a/doculects/amel1241-2.ini
+++ b/doculects/amel1241-2.ini
@@ -1,0 +1,56 @@
+[core]
+name = Amele
+glottocode = amel1241
+
+[source]
+url = https://www.silpacific.org/resources/archives/42321
+author = Roberts, John R.
+title = Amele Organised Phonology Data
+publisher = SIL
+year = 1998
+pages = 7
+
+[notes]
+
+[phonemes]
+b
+t
+d
+(k)
+g
+ʔ
+m
+n
+f
+s
+h
+j
+l
+w
+gb
+
+æ
+ɛ
+ɔ
+i
+u
+
+ɛi
+ɛu
+æi
+æu
+ɔi
+ɔu
+
+æː
+ɛː
+ɔː
+iː
+uː
+
+[allophonic_rules]
+g > k / _# except in monosyllables
+gb > p / _#
+b > p / _# except in monosyllables
+j > ʒ / #_, i_#, V_i
+w > ʋ / _i _e i_#

--- a/doculects/anem1248-1.ini
+++ b/doculects/anem1248-1.ini
@@ -1,0 +1,41 @@
+[core]
+name = Aneme Wake
+glottocode = anem1248
+
+[source]
+url = https://www.silpacific.org/resources/archives/42353
+author = Weimer, Harry
+title = Aneme Wake Organised Phonology Paper
+publisher = SIL
+year = 1992
+pages = 4
+
+[notes]
+
+[phonemes]
+b
+d
+k
+g
+m
+n
+r
+f
+s
+j
+w
+
+ɑ
+e
+o
+i
+u
+
+ei
+eu
+ɑi
+ɑu
+oi
+ou
+
+[allophonic_rules]

--- a/doculects/anga1290-1.ini
+++ b/doculects/anga1290-1.ini
@@ -1,0 +1,49 @@
+[core]
+name = Angaatɨha
+glottocode = anga1290
+
+[source]
+url = https://www.silpacific.org/resources/archives/42317
+author = Huisman, Ronald D.
+title = Angaatiha Organised Phonology Data
+publisher = SIL
+year = 1992
+pages = 5
+
+[notes]
+Some syllables are toneless.
+
+[phonemes]
+p
+t
+k
+ʔ
+m
+n
+ŋ
+ɾ|r|l
+ɕ|tɕ
+j
+w
+
+ɑː
+ɐ
+ə
+e
+o
+i
+u
+
+ɐi
+ɐu
+
+˥
+˩
+˥˩
+
+[allophonic_rules]
+ɕ > dʑ 
+ə > ɪ / contiguous to /s/ and /j/ and before /ʔ/
+ə > e / _ʔe unless it becomes [ɪ]
+ə > o / _ʔo unless /r/ precedes
+ə > ɑ / _ʔɑː

--- a/doculects/anga1293-1.ini
+++ b/doculects/anga1293-1.ini
@@ -1,0 +1,60 @@
+[core]
+name = Mendi
+glottocode = anga1293
+dialect = OPTIONAL
+
+[source]
+glottolog = 80103
+url = https://www.jstor.org/stable/30022555
+author = Rule, Joan
+title = A Comparison of Certain Phonemes of the Languages of the Mendi and Nembi Valleys, Southern Highlands, Papua
+publisher = Anthropological Linguistics
+volume = 7
+number = 5
+year = 1965
+pages = 8
+
+[notes]
+OPTIONAL
+
+[phonemes]
+p
+t
+k
+ⁿb
+ⁿd
+ⁿg
+ɕ
+ⁿdʑ
+m
+n
+l
+ɭ̆
+w
+j
+
+a
+ɛ
+æ
+ɑ
+ɒ
+o
+i
+u
+
+[allophonic_rules]
+k > kʰ / #_ _#
+k > g / word-medially
+
+p >~ pɸ / #_
+p >~ ɸ / #_
+p >~ b / word-medially
+p >~ pʰ / _#
+
+ⁿb > ⁿpʰ / _#
+t > tʰ ~ tɾ / #_
+t > ɾ ~ r / word-medially
+t > ɾ̥ / _#
+
+l > ɬ / _#
+ɭ̆ > ɭ̥̽ / _#

--- a/doculects/anja1238-1.ini
+++ b/doculects/anja1238-1.ini
@@ -1,0 +1,44 @@
+[core]
+name = Anjam
+glottocode = anja1238
+
+[source]
+url = https://www.silpacific.org/resources/archives/43563
+author = Rucker, Diane
+title = Anjam phonology essentials
+publisher = SIL
+year = 1990
+pages = 38
+
+[notes]
+
+
+[phonemes]
+p
+b
+t
+d
+k
+g
+q
+dʑ
+m
+n
+ȵ
+ŋ
+l
+r
+w
+j
+
+a
+e
+o
+i
+u
+
+[allophonic_rules]
+dʑ > tɕ / _#
+i > ɪ / nonfinal closed syllables
+e > ɛ / nonfinal closed syllables
+u > ʊ / nonfinal closed syllables

--- a/doculects/anja1238-2.ini
+++ b/doculects/anja1238-2.ini
@@ -1,0 +1,42 @@
+[core]
+name = Anjam
+glottocode = anja1238
+
+[source]
+url = https://www.silpacific.org/resources/archives/42330
+author = Rucker, Robert
+title = Anjam Organised Phonology Data
+publisher = SIL
+year = 2000
+pages = 5
+
+[notes]
+
+[phonemes]
+p
+b
+t
+d
+k
+g
+q
+m
+n
+ȵ
+ŋ
+r
+s
+j
+l
+w
+dʑ
+
+ɑ
+e
+o
+i
+u
+
+[allophonic_rules]
+b > p / _#
+dʑ > tɕ / _#

--- a/doculects/anka1246-1.ini
+++ b/doculects/anka1246-1.ini
@@ -1,0 +1,124 @@
+[core]
+name = Angave
+glottocode = anka1246
+
+[source]
+glottolog = 36478
+url = http://www.langlxmelanesia.com/LLM%%20vol%%2017%%20nos%%201-2%%20Phonological%%20processes%%20affecting%%20segments%%20in%%20Angave%%20part%%201%%20of%%204.pdf
+
+[notes]
+There are two words in which alveolars occur preceding /i/, so alveolopalatals could be marginally phonemic.
+
+/o̯/ is included here based on the description in Speece, Richard F. 1987. How shall we write what was left when the labialized post velar lost its velar?. In John M. Clifton (ed.), Studies in Melanesian orthographies, 45-55. Ukarumpa: Summer Institute of Linguistics. 
+
+/ɾ/ is included on the grounds of six forms with initial /t/ that never alternate with /ɾ/.
+
+It's unclear what the phonetic nature of the contrast is between the (stated to be coronal) palatalized velars and the alveolopalatals.
+
+All /æ ɔ/ are analyzed in the source as /ea oa/.
+
+/ʔ/ is analyzed as a suprasegmental.
+
+[phonemes]
+p
+t
+k
+kʷ
+q
+qʷ
+ⁿb
+ⁿd
+ⁿg
+ⁿgʷ
+m
+n
+ŋ
+ŋʷ
+w
+j
+(o̯)
+(ɾ)
+
+a
+e
+ə
+o
+i
+u
+
+ʔ
+
+[allophonic_rules]
+ɾ > t / #_ (see notes)
+
+k > ȶ / adjacent to high vowels
+kʷ > ȶʷ / adjacent to high vowels
+ⁿg > ⁿȡ / adjacent to high vowels
+ⁿgʷ > ⁿȡʷ / adjacent to high vowels
+ŋ > ȵ / adjacent to high vowels
+ŋʷ > ȵʷ / adjacent to high vowels
+
+p >~ ɸ / #_
+p > β / V_V
+ʔ+p > p / V_V
+
+t > ɾ / V_V
+ʔ+t > t / V_V
+
+k > ʝ ~ ç / V_V when adjacent to high vowels
+k > ɣ ~ x / V_V when not adjacent to high vowels
+ʔ+k > c / V_V when adjacent to high vowels
+ʔ+k > k / V_V when not adjacent to high vowels
+
+kʷ > ʝʷ ~ çʷ / V_V when adjacent to high vowels
+kʷ > ɣʷ ~ xʷ / V_V when not adjacent to high vowels
+ʔ+kʷ > cʷ / V_V when adjacent to high vowels
+ʔ+kʷ > kʷ / V_V when not adjacent to high vowels
+
+q > ʁ / V_V
+qʷ > ʁʷ / V_V
+
+t > tɕ / _i
+ⁿd > ⁿdʑ / _i
+n > ȵ > _i
+
+j > ʑ / medially in a stressed syllable
+
+i > iə̯ ~ i+j+ə / _q _qʷ
+e > eə̯ / _q _qʷ
+
+i > ə̯i / q_ qʷ_
+e > ɛ
+
+ə > ɪ / Ci_ (i.e. after alveolopalatals) unless followed by q
+ə > ɨ / _{ŋ ⁿg}
+ə > ᵻ / Ci_{ŋ ⁿg}
+ə > u / {w Cʷ}_ _{w Cʷ}
+ə > ʉ / {w Cʷ}_{ŋ ⁿg} (?)
+ə > ʌ / q_ _q
+ə > o / q_{w Cʷ} {w Cʷ}_q _qʷ (presumably also qʷ_?)
+
+ə > a / _ʔa
+ə > e / _ʔe
+ə > o / _ʔo
+ə > i / _ʔi
+ə > u / _ʔu
+
+a > ai̯ / _j
+a > au̯ / _C[+round]
+
+i+a > jæ / _
+u+a > wa / _
+e+a > æ / _
+o+a > ɔ / _
+a+e > æ / _
+a+o > ɔ / _
+
+ə > 0 / between homorganic consonants, unless one is a semivowel or a labialized consonant
+m+ə > m̩ / before a bilabial
+n+ə > n̩ / before a coronal
+ŋ+ə > ŋ̩ / before an unrounded velar
+ɾ+ə > r̩ / before a coronal
+m+ə+p > ⁿb
+n+ə+t > ⁿd
+ŋ+ə+k > ⁿg

--- a/doculects/anka1246-2.ini
+++ b/doculects/anka1246-2.ini
@@ -1,0 +1,48 @@
+[core]
+name = Angave
+glottocode = anka1246
+
+[source]
+url = https://www.silpacific.org/resources/archives/42301
+author = Speece, Richard F.
+title = Ankave Organised Phonology Data
+publisher = SIL
+year = 1992
+pages = 4
+
+[notes]
+VV and VVV nuclei are listed in addition to the four diphthongs given, but the only VVV nuclei listed (/ioɑ/ and /iɑu/) contain one of the four diphthongs.
+
+/t/ should probably be listed as ({t}), as per anka1246-1; the only cases of non-initial /t/ in the sample text are <Pitaoyá> and <Pitaomɨ> < Eng. _Peter_.
+
+[phonemes]
+p
+t
+k
+ʔ
+m
+n
+ŋ
+ɾ
+s
+x
+j
+w
+ⁿb
+ⁿd
+ⁿg
+ⁿdz
+
+ɑ
+ə
+e
+o
+i
+u
+
+ɑi
+iɑ
+eɑ
+oɑ
+
+[allophonic_rules]

--- a/doculects/anuk1239-1.ini
+++ b/doculects/anuk1239-1.ini
@@ -1,0 +1,59 @@
+[core]
+name = Anuki
+glottocode = anuk1239
+
+[source]
+url = https://www.silpacific.org/resources/archives/64101
+author = Landweer, M. Lynn; Schulz, Hanna
+title = Organised Phonology Data Anuki Language
+publisher = SIL
+year = 2000
+pages = 12
+
+[notes]
+OPTIONAL
+
+[phonemes]
+p
+b
+t
+d
+k
+g
+ʔ
+m
+n
+ɾ|r
+v
+s
+ɣ
+j
+w
+kʷ
+gʷ
+
+ɑ
+e
+o
+i
+ʊ
+u
+m̩
+
+ɨi
+(ɑe)
+ɑi
+ɑu
+ei
+eo
+eu
+iu
+oe
+oi
+
+[allophonic_rules]
+m > mʷ / _ɨi
+p > pʷ / _ɨi
+b > bʷ / _ɨi
+
+e > ɛ / when stressed

--- a/doculects/apma1241-1.ini
+++ b/doculects/apma1241-1.ini
@@ -1,0 +1,43 @@
+[core]
+name = Botin
+glottocode = apma1241
+
+[source]
+url = https://www.silpacific.org/resources/archives/42333
+author = Wade, Martha
+title = Botin Organised Phonology Data
+publisher = SIL
+year = 2011
+pages = 4
+
+[notes]
+
+
+[phonemes]
+p
+t
+k
+m
+n
+ɲ
+s
+j
+l|ɾ
+w
+ⁿb
+ⁿd
+ⁿg
+ⁿdʑ
+
+ɑ
+e
+o
+i
+ɨ
+u
+
+[allophonic_rules]
+ɑ >~ ə / _g
+ɑ > ə / unstressed except _#
+ⁿg > ŋ / _#
+u > w / C_i (?)

--- a/doculects/aram1253-1.ini
+++ b/doculects/aram1253-1.ini
@@ -1,0 +1,50 @@
+[core]
+name = Arammba
+glottocode = aram1253
+
+[source]
+glottolog = 138494
+url = https://www.diu.edu/documents/gialens/Vol3-2/Parker-Arammba.pdf
+author = Parker, Steve
+title = An affix-specific phoneme in Arammba
+publisher = GIALens
+year = 2009
+
+[notes]
+
+[phonemes]
+{p}
+t
+k
+b
+d
+dʒ|dʑ
+g
+ɸ
+s
+χ
+(ð)
+ⁿb
+ⁿd
+ⁿdʒ|ⁿdʑ
+ⁿg
+m
+n
+ŋ
+r
+w
+j
+
+i
+y
+u
+ø
+ə̆|ɛ̆
+ɛ
+ɜ̆|ʌ̆|ɔ̆
+ʌ
+ɔ
+æ
+a
+
+[allophonic_rules]

--- a/doculects/aram1253-2.ini
+++ b/doculects/aram1253-2.ini
@@ -1,0 +1,57 @@
+[core]
+name = Aramba
+glottocode = aram1253
+dialect = OPTIONAL
+
+[source]
+url = https://www.silpacific.org/resources/archives/71648
+author = Baku, Katawer; Findjar, Sawiyam; Pauw, Michel
+title = Tentative Grammar Description for the Aramba [stk] Language
+publisher = SIL
+year = 2016
+pages = 69
+
+[notes]
+No information is given about the pronunciation of orthographic <á é>. I've filled in the values from the Organised Phonology Data: <á> /a/, as opposed to <a> /ʌ/, and <é> /æ/.
+
+<dj> is stated to be a "voiced postalveolar fricative", but this is assumed to be an affricate here, based on the spelling.
+
+[phonemes]
+b
+ⁿb
+d
+ⁿd
+dʒ
+ⁿdʒ
+f
+g
+k
+m
+n
+ŋ
+ⁿg
+p
+r
+s
+t
+ð
+w
+x
+j
+
+ʔ
+
+a
+ă
+e
+ĕ|ə̆|iĕ
+i
+o
+ø
+u
+ʉ
+
+ʌ
+æ
+
+[allophonic_rules]

--- a/doculects/aram1253-3.ini
+++ b/doculects/aram1253-3.ini
@@ -1,0 +1,55 @@
+[core]
+name = Arammba
+glottocode = aram1253
+
+[source]
+url = https://www.silpacific.org/resources/archives/31303
+author = Parker, Steve
+title = Arammba Organised Phonology Data: Western Province (South-Fly-Morehead District)
+publisher = SIL
+year = 2005
+pages = 14
+
+[notes]
+The low vowels /a æ/ are longer than the mid vowels /ɛ ʌ ɔ ø/, which are longer than the high vowels, which are longer than the short vowels.
+
+There's vowel harmony between /ɜ̆ ʌ a u o/ and /ə̆ ɛ æ y ø/. /i/ is neutral.
+
+[phonemes]
+b
+t
+d
+k
+g
+m
+n
+ŋ
+r
+ɸ
+ð
+s
+χ
+j
+w
+dʒ
+ⁿb
+ⁿd
+ⁿdʒ
+ⁿg
+
+a
+æ
+ɛ
+ø
+ə̆
+ɜ̆
+ʌ
+ɔ
+i
+y
+u
+
+[allophonic_rules]
+y >~ ʉ
+ɛ >~ æ / note: presumably shorter than /æ/?
+ʌ >~ ɑ / note: presumably shorter than /a/?

--- a/doculects/aree1239-1.ini
+++ b/doculects/aree1239-1.ini
@@ -1,0 +1,45 @@
+[core]
+name = Are
+glottocode = aree1239
+
+[source]
+url = https://www.silpacific.org/resources/archives/56112
+author = Svensson, Erik; Svensson, Ingrid
+title = Are Organised Phonology Data
+publisher = SIL
+year = 2006
+pages = 9
+
+[notes]
+
+[phonemes]
+p
+b
+t
+d
+k
+g
+m
+n
+ɾ
+s
+j
+w
+kʷ
+gʷ
+
+a
+e
+o
+i
+u
+
+ai
+au
+ae
+ao
+ei
+ou
+
+[allophonic_rules]
+w > v ~ ʋ ~ β / _V[+front], except a few cases before /e/

--- a/doculects/arif1239-1.ini
+++ b/doculects/arif1239-1.ini
@@ -1,0 +1,42 @@
+[core]
+name = Miniafia-Oyan
+glottocode = arif1239
+dialect = OPTIONAL
+
+[source]
+glottolog = 551292
+url = https://www.silpacific.org/resources/archives/65194
+author = Oyabua, Stanley; Urasabey, Alfred; Sogiri, Vanessa
+title = Tentative Grammar Description for the Miniafia-Oyan [Min] Language
+year = 2015
+
+[notes]
+
+[phonemes]
+b
+d
+f
+g
+h
+k
+m
+n
+r
+s
+t
+v
+w
+j
+
+a
+e
+i
+o
+u
+aː
+eː
+iː
+oː
+uː
+
+[allophonic_rules]

--- a/doculects/arif1239-2.ini
+++ b/doculects/arif1239-2.ini
@@ -1,0 +1,55 @@
+[core]
+name = Miniafia
+glottocode = arif1239
+
+[source]
+url = https://www.silpacific.org/resources/archives/42232
+author = Wakefield, David C.
+title = Miniafia Organised Phonology Data
+publisher = SIL
+year = 1992
+pages = 4
+
+[notes]
+
+
+[phonemes]
+b
+w
+m
+t
+f
+d
+n
+k
+ɾ
+g
+s
+h
+j
+ʔ
+kʷ
+
+ɑ
+e
+o
+i
+u
+
+ii
+ei
+ee
+eɑ
+eo
+eu
+uu
+oi
+ou
+ɑi
+ɑɑ
+ɑu
+ɑo
+
+[allophonic_rules]
+w > v / _V[+front] or word space
+j > z / _V[+front] or word space

--- a/doculects/arop1242-1.ini
+++ b/doculects/arop1242-1.ini
@@ -1,0 +1,46 @@
+[core]
+name = Arop-Sissano
+glottocode = arop1242
+
+[source]
+url = https://www.silpacific.org/resources/archives/58388
+author = Whitacre, Steve
+title = Arop Phonemic Statement
+year = 1984
+
+[notes]
+
+[phonemes]
+p
+t
+tʃ
+k
+ʔ
+s
+m
+n
+ȵ
+l
+ȴ
+r
+w
+j
+
+i
+u
+e
+o
+ɛ
+a
+ɔ
+
+[allophonic_rules]
+a > ai / _{tʃ ȵ ȴ}
+o > oi / _{tʃ ȵ ȴ}
+u > ui / _{tʃ ȵ ȴ}
+
+p > b / C[+voice]_C[+voice]
+k > g / C[+voice]_
+n > ŋ / C[velar]
+ɛ >~ ɨ / _n
+a > æ / _ʔ

--- a/doculects/arop1242-2.ini
+++ b/doculects/arop1242-2.ini
@@ -1,0 +1,49 @@
+[core]
+name = Sissano
+glottocode = arop1242
+
+[source]
+url = https://www.silpacific.org/resources/archives/42264
+author = Nystrom, John
+title = Sissano Organised Phonology Data
+publisher = SIL
+year = 1992
+
+[notes]
+
+[phonemes]
+p
+t
+tɕ
+k
+ʔ
+m
+n
+ȵ
+r
+s
+j
+l
+ȴ
+w
+
+ɑ
+ɛ
+e
+o
+ʊ
+i
+u
+
+(ɑi)
+ɑː
+ɛː
+ʊː
+ɑu
+
+[allophonic_rules]
+p > b / C[+voice]_C[+voice]
+k > g / C[+voice]_
+t > tɕ / C[+palatal]_
+l > ȴ / C[+palatal]_
+n > ȵ / C[+palatal]_

--- a/doculects/arop1243-1.ini
+++ b/doculects/arop1243-1.ini
@@ -1,0 +1,44 @@
+[core]
+name = Arop-Lokep
+glottocode = arop1243
+
+[source]
+glottolog = 99006
+url = https://www.silpacific.org/resources/archives/23610
+author = Raymond, Mary; D'Jernes, Jeffrey
+title = Phonology essentials Arop-Lokep language
+year = 2005
+
+[notes]
+
+[phonemes]
+p
+t
+k
+s
+m
+n
+ŋ
+l
+r
+b
+d
+g
+(ʔ)
+
+i
+ɛ
+ɑ
+u
+o
+ɔ
+(ɨ)
+
+[allophonic_rules]
+k > ɣ / V_V
+d > ɾ / V_V[-stress]
+d > r / _$ or followed by a morpheme boundary in the "Arop 1 dialect"
+n > ɳ / V[back]_$
+l > ɭ / V[back]_$
+n+r > n+d+r / _
+ɨ > ɛ / for younger speakers (merger)

--- a/doculects/arop1243-2.ini
+++ b/doculects/arop1243-2.ini
@@ -1,0 +1,44 @@
+[core]
+name = Arop-Lokep
+glottocode = arop1243
+
+[source]
+glottolog = 12397
+doi = 10.1017/S002510030500188X
+author = Raymond, Mary; Parker, Steve
+title = Initial and medial geminate trills in Arop-Lokep
+publisher = Journal of the International Phonetic Association
+
+[notes]
+The existence of long vowels is mentioned (although they're noted to be uncommon), but details on which vowels can occur long aren't provided.
+
+[phonemes]
+p
+t
+k
+b
+d
+g
+s
+m
+n
+ŋ
+r
+l
+(ʔ)
+i
+ɛ
+(ɨ)
+a
+u
+o
+ɔ
+
+tː
+dː
+mː
+nː
+rː
+lː
+
+[allophonic_rules]

--- a/doculects/auuu1241-1.ini
+++ b/doculects/auuu1241-1.ini
@@ -1,0 +1,50 @@
+[core]
+name = Au
+glottocode = auuu1241
+
+[source]
+glottolog = 313260
+url = https://www.silpacific.org/resources/archives/31021
+author = Scorza, David P.
+title = Phonemes of the Au language
+publisher = SIL
+year = 1971
+pages = 22
+
+[notes]
+The long low vowel is interrupted by a glottal stop, [aʔa]. I'm not sure how this should be encoded; for now it's marked as glottalized, but this is used elsewhere in Papuan for "vowels with glottal closure". TODO
+
+[phonemes]
+p
+t
+k
+s
+ɣ
+m
+n
+r
+w
+j
+
+i
+ɨ
+u
+ʌ
+o
+a
+aː|aˀ
+
+[allophonic_rules]
+p >~ pʰ / _ except preceding nasals
+t >~ tʰ / _ except preceding nasals
+k >~ kʰ / _ except preceding nasals or /n r/
+p >~ b / _N
+t >~ d / _N or word-medially
+k >~ g / _{n r}
+n >~ l / word-medially
+
+i > ɪ / _{m n s r} except between two like consonants
+ɨ > ɣ+ɨ / $_
+u > ʊ / _N
+ʌ > ɛ / _{m n s r}
+ɨ+a > ɨ+ʔ+a

--- a/doculects/auuu1241-2.ini
+++ b/doculects/auuu1241-2.ini
@@ -1,0 +1,42 @@
+[core]
+name = Au
+glottocode = auuu1241
+
+[source]
+url = https://www.silpacific.org/resources/archives/42348
+author = Scorza, David P.
+title = Au Organised Phonology Data
+publisher = SIL
+year = 1992
+pages = 4
+
+[notes]
+
+
+[phonemes]
+p
+t
+k
+m
+n
+r
+s
+ɣ
+j
+w
+
+i
+ɨ
+u
+ə
+o
+ɑ
+
+ɑː
+ɑi
+ɑu
+əi
+iu
+
+[allophonic_rules]
+n >~ l / word-medially

--- a/doculects/awad1244-1.ini
+++ b/doculects/awad1244-1.ini
@@ -1,0 +1,55 @@
+[core]
+name = Awad Bing
+glottocode = awad1244
+dialect = yama1259
+dialect_name = Yamai
+
+[source]
+url = https://www.silpacific.org/resources/archives/56763
+author = King, Phil
+title = Awad Bing Orthography
+publisher = SIL
+year = 2000
+pages = 9
+
+[notes]
+
+[phonemes]
+p
+b
+m
+f
+w
+t̪
+d
+n
+s
+l
+r
+k
+g
+ŋ
+j
+(ʔ)
+
+a
+u
+i
+e
+o
+
+(aɛ)
+au
+e̝|ɛi
+iɛ
+(oa)
+ɔə
+ua
+uɔ
+uə
+
+
+˥
+˥˩
+
+[allophonic_rules]

--- a/doculects/awad1244-2.ini
+++ b/doculects/awad1244-2.ini
@@ -1,0 +1,59 @@
+[core]
+name = Awad Bing
+glottocode = awad1244
+dialect_name = Samang-Z
+dialect = bili1252
+
+[source]
+url = https://www.silpacific.org/resources/archives/56763
+author = King, Phil
+title = Awad Bing Orthography
+publisher = SIL
+year = 2000
+pages = 9
+
+[notes]
+Copied from awad1244-1; the only difference is that the /z/ phoneme has been added, since that's the only difference noted. (Yamai is a Samang-D dialect and the dialect survey reports 99% cognates, so presumably they aren't too different.)
+
+Samang-Z is assigned to bili1252 on the grounds that it's noted to be spoken in Biliau village.
+
+[phonemes]
+p
+b
+m
+f
+w
+t̪
+d
+n
+s
+l
+r
+k
+g
+ŋ
+j
+(ʔ)
+z
+
+a
+u
+i
+e
+o
+
+(aɛ)
+au
+e̝|ɛi
+iɛ
+(oa)
+ɔə
+ua
+uɔ
+uə
+
+
+˥
+˥˩
+
+[allophonic_rules]

--- a/doculects/awad1244-3.ini
+++ b/doculects/awad1244-3.ini
@@ -1,0 +1,60 @@
+[core]
+name = Awad Bing
+glottocode = awad1244
+dialect = yama1259
+dialect_name = Yamai
+
+[source]
+glottolog = 80928
+url = https://www.silpacific.org/resources/archives/57104
+author = Bennett, Douglas; King, Phil
+title = The Phonology and Orthography of Awad Bing
+year = 2000
+pages = 37
+
+[notes]
+Vowels with high tone are longer than vowels with falling tone.
+
+[phonemes]
+p
+t
+k
+(ʔ)
+b
+d
+g
+m
+n
+ŋ
+f
+s
+l
+r
+w
+j
+
+i
+u
+ɛ
+o
+a
+
+˥
+˥˩
+
+ei|e̝i|e̝
+ie
+ɔə
+ua
+au
+uɔ
+uəi
+
+[allophonic_rules]
+p >~ pʰ / _$
+t >~ tʰ / _$
+k >~ kʰ / _$
+
+i > ɪ / unstressed
+u > ʊ / unstressed
+o > ɔ / in monosyllabic VC words and V_

--- a/doculects/awad1244-4.ini
+++ b/doculects/awad1244-4.ini
@@ -1,0 +1,65 @@
+[core]
+name = Awad Bing
+glottocode = awad1244
+dialect = bili1252
+dialect_name = Samang-Z
+
+[source]
+glottolog = 80928
+url = https://www.silpacific.org/resources/archives/57104
+author = Bennett, Douglas; King, Phil
+title = The Phonology and Orthography of Awad Bing
+year = 2000
+pages = 37
+
+[notes]
+Copied from awad1244-3; the only difference is that the /z/ phoneme has been added, since that's the only difference noted.
+
+Samang-Z is assigned to bili1252 on the grounds that it's noted to be spoken in Biliau village.
+
+Vowels with high tone are longer than vowels with falling tone.
+
+[phonemes]
+p
+t
+k
+(ʔ)
+b
+d
+g
+m
+n
+ŋ
+f
+s
+l
+r
+w
+j
+z
+
+i
+u
+ɛ
+o
+a
+
+˥
+˥˩
+
+ei|e̝i|e̝
+ie
+ɔə
+ua
+au
+uɔ
+uəi
+
+[allophonic_rules]
+p >~ pʰ / _$
+t >~ tʰ / _$
+k >~ kʰ / _$
+
+i > ɪ / unstressed
+u > ʊ / unstressed
+o > ɔ / in monosyllabic VC words and V_

--- a/doculects/awap1236-1.ini
+++ b/doculects/awap1236-1.ini
@@ -1,0 +1,58 @@
+[core]
+name = Awa
+glottocode = awap1236
+
+[source]
+glottolog = 56728
+url = http://sealang.net/archives/pl/pdf/PL-A7.23.pdf
+author = Loving, Richard E.
+title = Awa phonemes, tonemes, and tonally differentiated allomorphs
+year = 1966
+
+[notes]
+TODO input allotonic information
+
+[phonemes]
+p
+t
+tʃ
+k
+ʔ
+m
+n
+w
+j
+
+i
+u
+e
+o
+æ
+ʌ
+a
+
+˥
+˥˩
+˩˥ 
+˩
+
+[allophonic_rules]
+p > b / V[+front]_V
+t > d / V[+front]_V
+k > g / V[+front]_V
+
+p > β / V[-front]_V
+t > ɾ / V[-front]_V
+k > ɣ / V[-front]_V
+
+tʃ > dʒ / n_
+
+n > ŋ / _k
+
+j > ʑ / _i
+
+u+m > m̩ / #_
+
+i > iː / phrase-finally
+u > uː / phrase-finally
+ʌ > ʌː / phrase-finally

--- a/doculects/awap1236-2.ini
+++ b/doculects/awap1236-2.ini
@@ -1,0 +1,49 @@
+[core]
+name = Awa
+glottocode = awap1236
+
+[source]
+url = https://www.silpacific.org/resources/archives/42328
+author = Loving, Richard
+title = Awa Organised Phonology Data
+publisher = SIL
+year = 1992
+
+[notes]
+
+
+[phonemes]
+p
+b
+t
+k
+g
+ʔ
+m
+n
+r
+j
+w
+ts̪
+
+i
+u
+e
+ə
+o
+æ
+ɑ
+
+˥
+˥˩
+˩˥ 
+˩
+
+
+[allophonic_rules]
+p > β / V[-front]_V 
+t > ɾ / V[-front]_V
+k > ɣ / V[-front]_V
+r > d / i_
+ts̪ > dz̪ / 
+j >~ z / _

--- a/doculects/awar1248-1.ini
+++ b/doculects/awar1248-1.ini
@@ -1,0 +1,83 @@
+[core]
+name = Awara
+glottocode = awar1248
+
+[source]
+glottolog = 70086
+url = https://arts-sciences.und.edu/academics/summer-institute-of-linguistics/theses/_files/docs/2003-quigley-edward-c.pdf
+author = Quigley, Edward C.
+title = Awara Phonology
+year = 2003
+
+[notes]
+/ə/ is shorter than the other vowels.
+
+/ŋ l ɣ/ can't occur initially in native words.
+
+The voiceless series is analyzed here as aspirated because loans have a distinct unaspirated, unvoiced series (see section 10.2) - e.g. [ɛlɪsəpɛt] < _Elizabeth_, [kalapus] < _kalabus_. The voiceless labiovelar is also assumed to be aspirated.
+
+[phonemes]
+ⁿb
+ⁿd
+ⁿg
+ⁿgʷ
+pʰ
+tʰ
+kʰ
+kʷʰ
+(ʔ)
+β|w
+ɣ|ɰ
+s
+(ʃ)
+h
+m
+n
+ŋ
+(ŋʷ)
+l|ɾ
+j
+
+a
+e
+ə
+o
+i
+u
+
+{p}
+{t}
+{k}
+
+{ai}
+{dʒ}
+{f}
+
+[allophonic_rules]
+ⁿb > b / #_
+ⁿd > d / #_
+ⁿg > g / #_
+ⁿgʷ > gʷ / #_
+
+ⁿb > ⁿp > V_V "in the southern dialect"
+ⁿd > ⁿt > V_V "in the southern dialect"
+ⁿg > ⁿk > V_V "in the southern dialect"
+ⁿgʷ > ⁿkʷ > V_V "in the southern dialect"
+
+pʰ > p / _$
+tʰ > t / _$
+kʰ > k / _$
+kʷʰ > kʷ / _$
+
+β > v / _i
+p > β / #_u
+
+s > ʃ
+
+k >~ kʷ / u_
+ⁿg >~ ⁿgʷ / u_
+ŋ >~ ŋʷ / u_
+
+i > ɪ / _m _l _ⁿB
+u > ʊ / _m _l _ⁿB
+e > ɛ / _m _l

--- a/doculects/awiy1238-1.ini
+++ b/doculects/awiy1238-1.ini
@@ -1,0 +1,47 @@
+[core]
+name = Awiyaana
+glottocode = awiy1238
+
+[source]
+url = https://www.silpacific.org/resources/archives/42395
+author = Marks, Doreen
+title = Awiyaana Organised Phonology Data
+publisher = SIL
+year = 1992
+pages = 4
+
+[notes]
+It's unclear whether the labial fricative is /ɸ/, /f/, or /v/. The unit analysis of labiovelars is mentioned but not followed in the source, but it's followed here since it's said to reduce the number of syllable types. (Presumably this means /kw gw/ are the only Cw clusters?)
+
+[phonemes]
+p
+b
+t
+d
+k
+g|ɣ
+ʔ
+m
+n
+ɾ
+ɸ
+s
+j
+w
+
+kʷ
+gʷ
+
+ɑ
+ʌ
+e
+o
+i
+u
+eː
+oː
+aː
+
+
+[allophonic_rules]
+ɾ > l / i_

--- a/doculects/bena1264-1.ini
+++ b/doculects/bena1264-1.ini
@@ -1,0 +1,53 @@
+[core]
+name = Benabena
+glottocode = bena1264
+
+[source]
+glottolog = 72887
+url = https://archive.org/details/rosettaproject_kbq_phon-1
+author = Young, Rosemary
+title = The phonemes of Kanite, Kamano, Benabena, and Gahuku
+year = 1962
+
+[notes]
+It's unclear whether /b/ is a stop or a fricative. (TODO: compare with other sources?)
+
+A page may be missing from the archive.org copy of the source.
+
+[phonemes]
+p
+t
+k
+ʔ
+b
+ʝ
+ɣ
+f
+s
+h
+ɽ|ɭ̆
+m
+n
+
+a
+e
+i
+o
+u
+
+[allophonic_rules]
+t >~ tʰ / #_
+k >~ kʰ / #_
+
+ʝ >~ j / $ˈ_V
+ʝ >~ z / $_V[-stress]
+s > ɕ / _i _u
+
+ʔ > p / _m
+ʔ > t / _n
+
+i >~ ɪ / initially and medially
+e >~ ɛ / initially and medially
+a >~ ʌ / medially and finally
+o >~ ɔ / initially and medially
+u >~ ʊ / initially and medially

--- a/doculects/kama1370-1.ini
+++ b/doculects/kama1370-1.ini
@@ -1,0 +1,43 @@
+[core]
+name = Kamano
+glottocode = kama1370
+
+[source]
+glottolog = 72887
+url = https://archive.org/details/rosettaproject_kbq_phon-1
+author = Young, Rosemary
+title = The phonemes of Kanite, Kamano, Benabena, and Gahuku
+year = 1962
+
+[notes]
+It's unclear whether /b/ is a stop or a fricative. (TODO: compare with other sources?)
+
+A page may be missing from the archive.org copy of the source.
+
+[phonemes]
+p
+t
+k
+ʔ
+b
+z
+g
+f
+s
+h
+ɾ|ɺ
+m
+n
+
+a|ʌ
+e|ɛ
+o|ɔ
+i|ɪ
+u|ʊ
+
+[allophonic_rules]
+t > ⁿt / all medial environments except following the glottal stop
+k > ⁿk / all medial environments except following the glottal stop
+
+e > e / final position
+e > ɛ / initial and medial position

--- a/doculects/kani1286-1.ini
+++ b/doculects/kani1286-1.ini
@@ -1,0 +1,59 @@
+[core]
+name = Kanite
+glottocode = kani1286
+dialect = OPTIONAL
+
+[source]
+glottolog = 72887
+url = https://archive.org/details/rosettaproject_kbq_phon-1
+author = Young, Rosemary
+title = The phonemes of Kanite, Kamano, Benabena, and Gahuku
+year = 1962
+
+[notes]
+High tone is stated to contrast with either low tone or tonelessness; the latter interpretation is taken here.
+
+It's unclear what /b/ is. (TODO: compare with other sources?)
+
+A page may be missing from the archive.org copy of the source.
+
+[phonemes]
+p
+t
+k
+ʔ
+b
+j|ʝ
+f
+s
+h
+ʟ̝
+m
+n
+
+a
+ʌ
+e|ɛ
+o
+i
+u
+ai
+au
+ʌi
+ʌu
+
+˥
+
+[allophonic_rules]
+n+t >~ tː
+k > k̠ / #_ ʔ_
+k > ɣ / V[-high]_V[-high]
+k > g / between two vowels, one of which is high
+
+e > e / in final position and low tone syllables
+e > ɛ / elsewhere
+
+a > æ / j_n n_j
+
+ʔ > p / _m
+ʔ > t / _n

--- a/doculects/weri1253-1.ini
+++ b/doculects/weri1253-1.ini
@@ -1,0 +1,61 @@
+[core]
+name = Wela
+glottocode = weri1253
+
+[source]
+glottolog = 80103
+url = https://www.jstor.org/stable/30022555
+author = Rule, Joan
+title = A Comparison of Certain Phonemes of the Languages of the Mendi and Nembi Valleys, Southern Highlands, Papua
+publisher = Anthropological Linguistics
+volume = 7
+number = 5
+year = 1965
+pages = 8
+
+[notes]
+/o/ is given twice, once in the place of <o'> /ɒ/. 
+
+The existence of the aspirated series is unclear; possibly these should be /p b/ series instead. /kʰ/ is assumed to be aspirated by analogy with the other stops in its series. But it's implied that the gap should be in the lenis non-prenasalized series... a lot is unclear here.
+
+/gʟ/ is given as /g/ in the chart, but described as a "uvular lateral affricate" in the text.
+
+/tʑ/ may be phonemic. (TODO: revisit this mess later)
+
+[phonemes]
+pʰ
+tʰ
+p|b
+t|d
+k
+ⁿb
+ⁿd
+ⁿg
+ɕ
+ʑ
+ⁿdʑ
+m
+n
+l
+gʟ
+w
+j
+ɭ̆
+a
+ɑ
+ɒ
+ɛ
+o
+i
+u
+
+[allophonic_rules]
+k > kʰ / _#
+k > tʑ / around high vowels? unclear
+ʑ > tʑ / #_ and optionally word-medially? unclear
+
+ⁿb > ⁿpʰ / _#
+p > p ~ b ~ β / medially
+l > ɺ̥ / _#
+gʟ > kʟ̥ / _#
+ɭ̆ > ɭ̥̆ / _#

--- a/test_commit.py
+++ b/test_commit.py
@@ -342,12 +342,13 @@ class CorrectTest(unittest.TestCase):
 				k
 				a
 				i
-				u
+				u|o
 
 				[allophonic_rules]
 				p > b / V_V
 				t > s ~ ts / _i
-				u >~ o / _"""), True)
+				t > ɾ
+				a+i >~ e"""), True)
 
 if __name__ == '__main__':
 	unittest.main()

--- a/test_commit.py
+++ b/test_commit.py
@@ -1,15 +1,15 @@
 import unittest
-from commit import validate
+import commit
 import configparser
 
 def v(str):
 	c = configparser.ConfigParser(allow_no_value=True)
 	c.read_string(string=str)
-	return validate(c)
+	return commit.validate(c)
 
 class CoreTest(unittest.TestCase):
 	def test_sections(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.IncorrectSectionsError):
 			v("""[core]
 				name = Test
 				glottocode = test1234
@@ -32,7 +32,7 @@ class CoreTest(unittest.TestCase):
 				u >~ o / _""")
 
 	def test_core_name(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.MissingPropertyError):
 			v("""[core]
 				glottocode = test1234
 
@@ -55,8 +55,8 @@ class CoreTest(unittest.TestCase):
 				t > s ~ ts / _i
 				u >~ o / _""")
 
-	def test_core_glottolog(self):
-		with self.assertRaises(Exception):
+	def test_core_glottocode(self):
+		with self.assertRaises(commit.MissingPropertyError):
 			v("""[core]
 				name = Test
 
@@ -80,7 +80,7 @@ class CoreTest(unittest.TestCase):
 				u >~ o / _""")
 
 	def test_core_name_required(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.MissingPropertyError):
 			v("""[core]
 				name = REQUIRED
 				glottocode = test1234
@@ -105,7 +105,7 @@ class CoreTest(unittest.TestCase):
 				u >~ o / _""")
 
 	def test_core_glottocode_required(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.MissingPropertyError):
 			v("""[core]
 				name = Test
 				glottocode = REQUIRED
@@ -130,7 +130,7 @@ class CoreTest(unittest.TestCase):
 				u >~ o / _""")
 
 	def test_core_null_name(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.MissingPropertyError):
 			v("""[core]
 				name
 				glottocode = test1234
@@ -155,7 +155,7 @@ class CoreTest(unittest.TestCase):
 				u >~ o / _""")
 
 	def test_core_null_glottocode(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.MissingPropertyError):
 			v("""[core]
 				name = Test
 				glottocode
@@ -180,7 +180,7 @@ class CoreTest(unittest.TestCase):
 				u >~ o / _""")
 
 	def test_core_blank_name(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.MissingPropertyError):
 			v("""[core]
 				name =   
 				glottocode = test1234
@@ -206,7 +206,7 @@ class CoreTest(unittest.TestCase):
 
 class SourceTest(unittest.TestCase):
 	def test_no_glottolog_no_author(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.MissingPropertyError):
 			v("""[core]
 				name = Test
 				glottocode = test1234
@@ -232,7 +232,7 @@ class SourceTest(unittest.TestCase):
 				u >~ o / _""")
 
 	def test_invalid_glottolog(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.InvalidPropertyError):
 			v("""[core]
 				name = Test
 				glottocode = test1234
@@ -258,13 +258,13 @@ class SourceTest(unittest.TestCase):
 
 class PhonemesTest(unittest.TestCase):
 	def test_no_phonemes(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.MissingPropertyError):
 			v("""[core]
 				name = Test
 				glottocode = test1234
 
 				[source]
-				glottolog = fakeid
+				glottolog = 1234
 				url = http://example.com/
 
 				[notes]
@@ -276,13 +276,13 @@ class PhonemesTest(unittest.TestCase):
 				""")
 
 	def test_phonemes_REQUIRED(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(commit.MissingPropertyError):
 			v("""[core]
 				name = Test
 				glottocode = test1234
 
 				[source]
-				glottolog = fakeid
+				glottolog = 1234
 				url = http://example.com/
 
 				[notes]
@@ -294,13 +294,13 @@ class PhonemesTest(unittest.TestCase):
 				""")
 
 	def test_no_duplicate_phonemes(self):
-		with self.assertRaises(Exception):
+		with self.assertRaises(configparser.DuplicateOptionError):
 			v("""[core]
 				name = Test
 				glottocode = test1234
 
 				[source]
-				glottolog = fakeid
+				glottolog = 1234
 				url = http://example.com/
 
 				[notes]

--- a/test_commit.py
+++ b/test_commit.py
@@ -343,11 +343,13 @@ class CorrectTest(unittest.TestCase):
 				a
 				i
 				u|o
+				(f)
 
 				[allophonic_rules]
 				p > b / V_V
 				t > s ~ ts / _i
 				t > ɾ
+				f > h / _a
 				a+i >~ e"""), True)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Also added a dialect_name field to the spec and noted the notational distinction between alveolopalatals (Sinological curled letters) and prevelar palatals (IPA palatal letters).